### PR TITLE
CP-54010: Use xapi for ssh in xsconsole

### DIFF
--- a/XSConsoleData.py
+++ b/XSConsoleData.py
@@ -1089,6 +1089,12 @@ class Data:
         self.RequireSession()
         self.session.xenapi.host.disable(self.host.opaqueref())
 
+    def EnableSSH(self):
+        self.session.xenapi.host.enable_ssh(self.host.opaqueref())
+
+    def DisableSSH(self):
+        self.session.xenapi.host.disable_ssh(self.host.opaqueref())
+
     def Ping(self,  inDest):
         # Must be careful that no unsanitised data is passed to the command
         if not re.match(r'[0-9a-zA-Z][-0-9a-zA-Z.]*$',  inDest):

--- a/plugins-base/XSFeatureRemoteShell.py
+++ b/plugins-base/XSFeatureRemoteShell.py
@@ -57,11 +57,9 @@ class RemoteShellDialogue(Dialogue):
         try:
             message = Lang("Configuration Successful")
             if inChoice:
-                data.EnableService('sshd')
-                data.StartService('sshd')
+                data.EnableSSH()
             else:
-                data.DisableService('sshd')
-                data.StopService('sshd')
+                data.DisableSSH()
 
                 if ShellPipe(['/sbin/pidof', 'sshd']).CallRC() == 0: # If PIDs are available
                     message = Lang("New connections via the remote shell are now disabled, but there are "


### PR DESCRIPTION
Currently, xsconsole uses systemd to manage ssh service. In the ssh configuration feature (CP-50702), ssh's status is saved in xapi DB and is updated by xapi API.
So change the way of managing ssh to xapi API in xsconsole to keep the ssh's status updating.